### PR TITLE
Improve grammar and reword in "Entering Protected Mode"

### DIFF
--- a/src/ch02-02-entering-protected-mode.md
+++ b/src/ch02-02-entering-protected-mode.md
@@ -166,7 +166,7 @@ Now, to apply all of the created functionality, enable protected mode, and final
 
 But just before that, when we jump to the next stage, we need to specify the offset in the GDT of the relevant section we want to jump to, which will load the `cs` segment register with that value. In that case it is the `kernel_code` section that will allow us to run code on ring0. For an easy way to specify the section, we will create an enum.
 
-_Notice that this also contains segments of other GDT that we will use in the future._
+_Notice that this also contains segments of another GDT that we will used in the following chapters._
 
 ```rust,fp=<repo>crates/common/src/enums/global_descriptor_table.rs#L8
 #![enum!("crates/common/src/enums/global_descriptor_table.rs", Sections)]

--- a/src/ch02-02-entering-protected-mode.md
+++ b/src/ch02-02-entering-protected-mode.md
@@ -16,7 +16,7 @@ Entering protected mode requires us to initialize the [`Global Descriptor Table`
 
 ## The Global Descriptor Table
 
-> _All the information about the global descriptor table is taken from both the [Intel Manual Volume 3A](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf&ved=2ahUKEwjK-duH0pOUAxXvhf0HHRkeN1sQFnoECA0QAQ&usg=AOvVaw3xCH_sFKn73Bg5tPFbOzaC) section 3.4.5, and the great [osdev](https://wiki.osdev.org/GDT_Tutorial) website._
+> _All the information about the Global Descriptor Table is taken from both the [Intel Manual Volume 3A](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf&ved=2ahUKEwjK-duH0pOUAxXvhf0HHRkeN1sQFnoECA0QAQ&usg=AOvVaw3xCH_sFKn73Bg5tPFbOzaC) section 3.4.5, and the great [osdev](https://wiki.osdev.org/GDT_Tutorial) website._
 
 This is a structure that is specific to the x86 CPU family, and it contains information about the different segments.
 In general, segments are used to divide memory into logical parts, and to translate addresses as we seen in real mode.
@@ -29,7 +29,7 @@ they can't hold enough information for us. That is where the Global Descriptor T
 The Global Descriptor Table is an array of structures that include information about a segment.
 When we want to use our custom segment, we load its offset on the GDT to the segment register.
 For example, we can create a segment for user data at index 1 of our table.
-This segment will not hold important data for the system, or code that can be executed.
+This segment will not hold important data for the system or code that can be executed.
 If we want to load it into the `ds` we will set it to the offset of the structure in the table.
 
 _Each entry is 8 bytes long, index one will be at an offset of 8, which means we will set `ds=8`_
@@ -59,15 +59,15 @@ Our entry will look like this:
 
 But what are these fields?
 - **Base:** This is a 32-bit value, which is split on the entire entry and represents the address of where the segment begins.
-- **Limit:** this is a 20-bit value, which is split on the entire entry and represents the size of the segment.
-- **Access Byte:** flags that are relevant to the memory range of the segment,
+- **Limit:** This is a 20-bit value, which is split on the entire entry and represents the size of the segment.
+- **Access Byte:** Flags that are relevant to the memory range of the segment,
 like the access privileges of this segment.
-- **Flags:** general flags that are relevant for the entry fields.
+- **Flags:** General flags that are relevant for the entry fields.
 
 All of these fields will become a struct and together they represent a single entry in our GDT.
 
 
-Both the `AccessByte` and the `LimitFlags` and more structures throughout the book, are using one bit flags, which represent some inner settings of the CPU.
+Both the `AccessByte`, the `LimitFlags`, and more structures throughout the book, are using one bit flags, which represent some inner settings of the CPU.
 Although setting a one bit flag is easy, and can be done with `1 << bit_number` to set the nth bit, we would like abstractions such as `set_<flag_name>`, which are more readable and less prone to errors.
 But, if we would do that to every flag, it will be **A LOT** of boilerplate code.
 For this reason, Rust provides us with an amazing macro system.
@@ -85,11 +85,13 @@ This macro was used to define those exactly 1 bit flags. But as it will turn out
 
 </blockquote>
 
-The problem that this macro had, is that the generated bit flag functions were defined to a struct that simply wrapped an integer type instead of having fields for each bit flag.  At first glance this seems almost the same. But, because the macro is run for each individual flag instead of all of them, it cannot generate the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait automatically when we want to print and look at the flags.
+The problem with this macro is that it had to be called for each bit flag. Because it did not take multiple flags, the macro did not have enough context to generate a [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait implementation that shows bit flag names.
+
+is it created one bit flag function for a struct that simply wrapped an integer type instead of having fields for each bit flag.  At first glance this seems almost the same. But, because the macro is run for each individual flag instead of all of them, it cannot generate the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait automatically when we want to print and look at the flags.
 
 _More problems that I was having, but not a direct outcome of the initial design, is that flags sometimes contain more than 1 bit, and may contain n bits, also, certain n bit flags may have a specific set of values that are valid, and we may want to name them in an enum._
 
-The current design of the macros looks like this:
+The current design of the macro looks like this:
 
 ```rust,fp=<repo>crates/arch/x86/src/structures/global_descriptor_table.rs#L6
 #![struct!("crates/arch/x86/src/structures/global_descriptor_table.rs", AccessByte)]
@@ -97,11 +99,11 @@ The current design of the macros looks like this:
 
 As you can see, we have the macro attribute at the top of our struct, which is called `bitfields`.
 
-- Each field in this struct, is a flag, and as you can see, the highlighter is smart and can expand our macro, so the color of the fields are the same as a function.
+- Each field in this struct is a flag, and as you can see, the highlighter is smart and can expand our macro, so the color of the fields are the same as a function.
 
 - The type of each field represents the flag width in bits. B1 is one bit and B20 is 20 bits.
 
-- Some flags may have their own attribute such as `r` and `w` which create a read function and a write function, respectively. When they are undefined, both functions are created.
+- Some flags may have their own attribute such as `r` and `w` which create a read function and a write function, respectively. When they are not defined, both functions are created.
 
 - Flags may also contain types, which are mostly enums that contains the valid values, or even all the values but gives them a readable name.
 
@@ -122,7 +124,7 @@ To see what this macro generated, we can use the amazing [`cargo-expand`](https:
 
 If this macro seems really cool and complicated, that's great! because it will be fully explained and implemented in later chapters.
 
-_We will also define an enum that will include the protection level and the system segment type, so that it is clear._
+_We will also define an enum that will include the protection level and the system segment flags so that they have clear names._
 
 ```rust,fp=<repo>crates/common/src/enums/general.rs
 #![enum!("crates/common/src/enums/general.rs", ProtectionLevel)]
@@ -151,18 +153,18 @@ Together it will all look like this:
 ```
 
 If you noticed, all of the functions that we defined so far are marked with `const`. this is useful because we can create our Global Descriptor Table as a static variable, which will be in the binary.
-This is useful because it will initialize our global descriptor table during compile time.
+This is useful because it will initialize our Global Descriptor Table during compile time.
 
-So, the only thing left to do is to load the global descriptor table. This can be done with the `lgdt` instruction which loads the `Global Descriptor Table Register` with our table. This is a hidden register that includes information about our global descriptor table, like it's size and address in memory.
+So, the only thing left to do is to load the Global Descriptor Table. This can be done with the `lgdt` instruction which loads the `Global Descriptor Table Register` with our table. This is a hidden register that includes information about our Global Descriptor Table, like it's size and address in memory.
 
-We will create a `load` function that will create this register structure, and load it to the CPU.
+We will create a `load` function that will create this register structure and load it to the CPU.
 
 ```rust,fp=<repo>crates/arch/x86/src/structures/global_descriptor_table.rs#L312
 #![struct!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableRegister)]
 #![impl_method!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableProtected::load)]
 ```
 
-Now, to apply all of the created functionality, enable protected mode. To jump to the next stage, we need to add the following code to our entry function.
+Now, to apply all of the created functionality, enable protected mode, and finally jump to the next stage, we need to add the following code to our entry function.
 
 But just before that, when we jump to the next stage, we need to specify the offset in the GDT of the relevant section we want to jump to, which will load the `cs` segment register with that value. In that case it is the `kernel_code` section that will allow us to run code on ring0. For an easy way to specify the section, we will create an enum.
 

--- a/src/ch02-02-entering-protected-mode.md
+++ b/src/ch02-02-entering-protected-mode.md
@@ -87,8 +87,6 @@ This macro was used to define those exactly 1 bit flags. But as it will turn out
 
 The problem with this macro is that it had to be called for each bit flag. Because it did not take multiple flags, the macro did not have enough context to generate a [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait implementation that shows bit flag names.
 
-is it created one bit flag function for a struct that simply wrapped an integer type instead of having fields for each bit flag.  At first glance this seems almost the same. But, because the macro is run for each individual flag instead of all of them, it cannot generate the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait automatically when we want to print and look at the flags.
-
 _More problems that I was having, but not a direct outcome of the initial design, is that flags sometimes contain more than 1 bit, and may contain n bits, also, certain n bit flags may have a specific set of values that are valid, and we may want to name them in an enum._
 
 The current design of the macro looks like this:

--- a/src/ch02-02-entering-protected-mode.md
+++ b/src/ch02-02-entering-protected-mode.md
@@ -6,39 +6,39 @@ _"With great power comes great responsibility." - Voltaire / Spider-Man_
 
 As you may recall from previous chapters, our BIOS only loads the first sector to RAM, which leaves about just shy of 512 bytes[^1].
 After we read from disk, it will enable us to write much more code, because we will not be limited to 512 bytes.
-But just before we do that, we don't want to limit ourselves only to 16bit instructions.
-For that we need to enter [`protected mode`](https://en.wikipedia.org/wiki/Protected_mode) which will allow us to unlock some cpu features such as 32bit instructions.
+But just before we do that, we don't want to limit ourselves to only 16bit instructions.
+For that we need to enter [`protected mode`](https://en.wikipedia.org/wiki/Protected_mode) which will allow us to unlock some CPU features such as 32bit instructions.
 
-[^1]: 446 bytes to be exact, this number is derived by removing the size of the partition table (64 bytes) and the size of the boot signature(2 bytes) from the sector size (512 bytes). 
+[^1]: 446 bytes to be exact. This number is derived by removing the size of the partition table (64 bytes) and the size of the boot signature(2 bytes) from the sector size (512 bytes). 
 
-Entering protected mode requires us to initialize the [`global descriptor table`](https://wiki.osdev.org/Global_Descriptor_Table) which is a CPU structure that will be discussed in depth below, and toggling the protected mode bit in [`cr0`](https://en.wikipedia.org/wiki/Control_register)
+Entering protected mode requires us to initialize the [`Global Descriptor Table`](https://wiki.osdev.org/Global_Descriptor_Table) (GDT) which is a CPU structure that will be discussed in depth below, as well as toggling the protected mode bit in [`cr0`](https://en.wikipedia.org/wiki/Control_register).
 
 
 ## The Global Descriptor Table
 
-> _All the information about the global descriptor table is taken from both the [Intel Manual Volume 3A](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf&ved=2ahUKEwjK-duH0pOUAxXvhf0HHRkeN1sQFnoECA0QAQ&usg=AOvVaw3xCH_sFKn73Bg5tPFbOzaC) section 3.4.5, and the great [osdev](https://wiki.osdev.org/GDT_Tutorial) website_
+> _All the information about the global descriptor table is taken from both the [Intel Manual Volume 3A](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf&ved=2ahUKEwjK-duH0pOUAxXvhf0HHRkeN1sQFnoECA0QAQ&usg=AOvVaw3xCH_sFKn73Bg5tPFbOzaC) section 3.4.5, and the great [osdev](https://wiki.osdev.org/GDT_Tutorial) website._
 
-This is a structure that is specific to the x86 cpu family, and it contains information about the different segments.
+This is a structure that is specific to the x86 CPU family, and it contains information about the different segments.
 In general, segments are used to divide memory into logical parts, and to translate addresses as we seen in real mode.
 
-_Address translation with the GDT will not be wildely used in this chapter, because it will not be used throughout the OS and memory paging, which will be explained in the next chapter will be used._
-_For now, think of a memory segment as a fixed size blob of contiguous physical memory_ 
+_Address translation with the GDT will not be wildly used in this chapter, because it will not be used throughout the OS. Instead, memory paging will be used and explained in the next chapter._
+_For now, think of a memory segment as a fixed size blob of contiguous physical memory._ 
 
-In protected mode, the common way to organize memory is using these segments. Because segments registers[^2] can only hold one number,
-they can't hold enough information for us, and that is where the global descriptor table comes in place.
-The global descriptor table is an array of structures that include information about a segment,
-when we want to use our custom segment, we load it's offset on the GDT to the segment register.
-For example, we can create a segment for user data at index one of our table.
-This segment will not hold important data for the system, and will not contain code that can be executed,
-if we want to load it into the `ds` we will set it to the offset of the structure in the table.
+In protected mode, the common way to organize memory is using these segments. Because segment registers[^2] hold only one number,
+they can't hold enough information for us. That is where the Global Descriptor Table comes in place.
+The Global Descriptor Table is an array of structures that include information about a segment.
+When we want to use our custom segment, we load its offset on the GDT to the segment register.
+For example, we can create a segment for user data at index 1 of our table.
+This segment will not hold important data for the system, or code that can be executed.
+If we want to load it into the `ds` we will set it to the offset of the structure in the table.
 
-_Each entry is 8 bytes long, index one will be at an offset of 8, which means we will set ds=8_
+_Each entry is 8 bytes long, index one will be at an offset of 8, which means we will set `ds=8`_
 
-[^2]: Registers like cs, ds, gs, fs, ss etc.
+[^2]: Registers like cs, ds, gs, fs, ss, etc.
 
-> Instead of just revealing you the structure that is used for each segment, I want you to pause and ponder about what each segment should include.
+> Instead of just revealing the structure that is used for each segment, I want you to pause and ponder: what information should each segment include?
 >
-> _Remember that some instructions assume segments, like mov, jmp etc. and we want segments for the kernel, users, data and code_
+> _Remember that some instructions assume segments, like mov, jmp etc. and we want segments for the kernel, users, data and code._
 
 When I asked myself this question, I came up with the following ideas:
 - What is the initial address of the segment. i.e the start address in memory where the segment starts.
@@ -46,31 +46,31 @@ When I asked myself this question, I came up with the following ideas:
 - What the segment includes. i.e data segment, code segment etc.
 - What is the privilege level of the segment. i.e can anyone access it or only the kernel
 - For a data segment, Is the data read only, or may I modify it?
-- For a code segment, Can I execute it, or not yet.
+- For a code segment, can I execute it or not yet.
 
-If you gussed something that is similar to this, you are mostly correct!
+If you guessed something similar to this, you are mostly correct!
 
 Our entry will look like this:
 <figure style="margin: 0; text-align: center">
   <img src="assets/gdt_struct.svg"></img>
-  <figcaption><strong>Figure 2-1:</strong> global descriptor table entry structure</figcaption>
+  <figcaption><strong>Figure 2-1:</strong> Global Descriptor Table entry structure</figcaption>
 </figure>
 
 
 But what are these fields?
-- **Base:** this is a 32-bit value, which is split on the entire entry and it represents the address of where the segment begins.
-- **Limit:** this is a 20-bit value, which is split on the entire entry, and it represents the size of the segment.
+- **Base:** This is a 32-bit value, which is split on the entire entry and represents the address of where the segment begins.
+- **Limit:** this is a 20-bit value, which is split on the entire entry and represents the size of the segment.
 - **Access Byte:** flags that are relevant to the memory range of the segment,
 like the access privileges of this segment.
 - **Flags:** general flags that are relevant for the entry fields.
 
-All of these fields will become a struct and together they represent a single entry on our GDT.
+All of these fields will become a struct and together they represent a single entry in our GDT.
 
 
-Both the `AccessByte` and the `LimitFlags` and more structures throughout the book, are using one bit flags, which represents some inner settings to the CPU.
-Although setting one bit flag is easy, and can be done with `1 << bit_number` to set the nth bit, we would like abstractions such as `set_<flag_name>`, which are more readable and less prone to errors.
-But, if we would do that to every flag, it will be **A LOT** of boiler plate code.
-For this reason, Rust provides us with an amazing macro system
+Both the `AccessByte` and the `LimitFlags` and more structures throughout the book, are using one bit flags, which represent some inner settings of the CPU.
+Although setting a one bit flag is easy, and can be done with `1 << bit_number` to set the nth bit, we would like abstractions such as `set_<flag_name>`, which are more readable and less prone to errors.
+But, if we would do that to every flag, it will be **A LOT** of boilerplate code.
+For this reason, Rust provides us with an amazing macro system.
 
 <blockquote>
 
@@ -85,11 +85,11 @@ This macro was used to define those exactly 1 bit flags. But as it will turn out
 
 </blockquote>
 
-The problem that this macro had, is that the struct the these functions were defined on, didn't understand that it was a structure that contains bit flags, but it was rather a struct that wraps an integer type, and it has functions that is defined on it to turn specific bits. At first glance this seems almost the same. But, because the macro doesn't get as input all the information on the flags, but rather 'per flag' input, it cannot implement the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait automatically when we want to print and look on the flags.
+The problem that this macro had, is that the generated bit flag functions were defined to a struct that simply wrapped an integer type instead of having fields for each bit flag.  At first glance this seems almost the same. But, because the macro is run for each individual flag instead of all of them, it cannot generate the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait automatically when we want to print and look at the flags.
 
-_More problems that are I was having, but are not a direct outcome of the initial design, is that flags sometimes contain more than 1 bit, and may contain n bits, also, certain n bit flags may have a specific set of values that are valid, and we may want to name them in an enum_
+_More problems that I was having, but not a direct outcome of the initial design, is that flags sometimes contain more than 1 bit, and may contain n bits, also, certain n bit flags may have a specific set of values that are valid, and we may want to name them in an enum._
 
-The current design of this macros, looks like this:
+The current design of the macros looks like this:
 
 ```rust,fp=<repo>crates/arch/x86/src/structures/global_descriptor_table.rs#L6
 #![struct!("crates/arch/x86/src/structures/global_descriptor_table.rs", AccessByte)]
@@ -97,11 +97,11 @@ The current design of this macros, looks like this:
 
 As you can see, we have the macro attribute at the top of our struct, which is called `bitfields`.
 
-- Each field in this struct, is a flag, and as you can see, the highlighter is smart and can expand our macro, so the color of the field is the same as functions.
+- Each field in this struct, is a flag, and as you can see, the highlighter is smart and can expand our macro, so the color of the fields are the same as a function.
 
 - The type of each field represents the flag width in bits. B1 is one bit and B20 is 20 bits.
 
-- Some flags can have their own attribute, which may contain r and w, which creates only read function, or write function (defaults to both)
+- Some flags may have their own attribute such as `r` and `w` which create a read function and a write function, respectively. When they are undefined, both functions are created.
 
 - Flags may also contain types, which are mostly enums that contains the valid values, or even all the values but gives them a readable name.
 
@@ -112,7 +112,7 @@ As you can see, we have the macro attribute at the top of our struct, which is c
 To see what this macro generated, we can use the amazing [`cargo-expand`](https://crates.io/crates/cargo-expand) tool created by [`David Tolnay`](https://github.com/dtolnay)
 
 <details>
-<summary>For example, the expansion of the call above</summary>
+<summary>For example, the expansion of the call above.</summary>
 
 ```rust
 #![source_file!("snippets/src/book/flag_macro_expand.rs")]
@@ -120,9 +120,9 @@ To see what this macro generated, we can use the amazing [`cargo-expand`](https:
 </details>
 </blockquote>
 
-If this macro seems really cool and complicated, that's great! because it will be fully explained and implemented in later chpaters.
+If this macro seems really cool and complicated, that's great! because it will be fully explained and implemented in later chapters.
 
-_We will also define an enum that will include the protection level and the system segment type, so it would be more clear_
+_We will also define an enum that will include the protection level and the system segment type, so that it is clear._
 
 ```rust,fp=<repo>crates/common/src/enums/general.rs
 #![enum!("crates/common/src/enums/general.rs", ProtectionLevel)]
@@ -130,7 +130,7 @@ _We will also define an enum that will include the protection level and the syst
 ```
 
 
-Now, just before creating a `new` function to our entry, we don't want each time to specify the base in three parts and the limit in two parts, instead we want the `new` function to abstract it from us.
+Now, just before creating a `new` function for our entry, we don't want to specify the base in three parts and the limit in two parts every time. Instead, we want the `new` function to do that for us.
 
 ```rust,fp=<repo>crates/arch/x86/src/structures/global_descriptor_table.rs#L39
 #![struct!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableEntry32)]
@@ -138,10 +138,10 @@ Now, just before creating a `new` function to our entry, we don't want each time
 ```
 ## Jumping to the next stage!
 
-Now, after understanding the global descriptor table, we want to jump to the next stage.
-This will require us to create and load a temporary global descriptor table.
+Now, after understanding the Global Descriptor Table, we want to jump to the next stage.
+This will require us to create and load a temporary Global Descriptor Table.
 
-Each table must have at least three entries, an initial `null` entry that is filled with zeros, which is always required as the first entry, a `data` entry for the data segment so we can read and write to memory, and `code` entry so we can execute code.
+Each table must have at least three entries: an initial `null` entry that is filled with zeros, which is always required as the first entry; a `data` entry for the data segment, so we can read and write to memory; and a `code` entry, so we can execute code.
 
 Together it will all look like this:
 
@@ -150,23 +150,23 @@ Together it will all look like this:
 #![impl_method!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableProtected::default)]
 ```
 
-If you noticed, all of the functions that we defined so far are marked with `const` this is useful because we can create our global descriptor table as a static variable, which will be in the binary.
-This is useful because it will make our initialization of the global descriptor table to be in compile time.
+If you noticed, all of the functions that we defined so far are marked with `const`. this is useful because we can create our Global Descriptor Table as a static variable, which will be in the binary.
+This is useful because it will initialize our global descriptor table during compile time.
 
 So, the only thing left to do is to load the global descriptor table. This can be done with the `lgdt` instruction which loads the `Global Descriptor Table Register` with our table. This is a hidden register that includes information about our global descriptor table, like it's size and address in memory.
 
-We will create a `load` function that will create this register structure, and will load it to the cpu.
+We will create a `load` function that will create this register structure, and load it to the CPU.
 
 ```rust,fp=<repo>crates/arch/x86/src/structures/global_descriptor_table.rs#L312
 #![struct!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableRegister)]
 #![impl_method!("crates/arch/x86/src/structures/global_descriptor_table.rs", GlobalDescriptorTableProtected::load)]
 ```
 
-Now, to apply all of the created functionality, enable protected mode, and to jump to the next stage, we need to add the following code to our entry function.
+Now, to apply all of the created functionality, enable protected mode. To jump to the next stage, we need to add the following code to our entry function.
 
-But just before that, when we jump to the next stage, we need to specify the offset in the GDT of the relevant section we want to jump to, which will load the cs segment register with that value. In that case it is the `kernel_code` section, which will allow us to run code on ring0. For an easy way to specify the section, we will create an enum.
+But just before that, when we jump to the next stage, we need to specify the offset in the GDT of the relevant section we want to jump to, which will load the `cs` segment register with that value. In that case it is the `kernel_code` section that will allow us to run code on ring0. For an easy way to specify the section, we will create an enum.
 
-_Notice that this also contains segments of other GDT that we will use in the future_
+_Notice that this also contains segments of other GDT that we will use in the future._
 
 ```rust,fp=<repo>crates/common/src/enums/global_descriptor_table.rs#L8
 #![enum!("crates/common/src/enums/global_descriptor_table.rs", Sections)]


### PR DESCRIPTION
The biggest rewording is at line 88. 

Is GDT at line 169 singular or plural?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and standardized explanation of protected mode and the Global Descriptor Table
  * Rewrote prose for consistency and improved terminology/footnote formatting
  * Expanded Rust macro discussion with clear bitfield attribute usage and examples
  * Added an expanded example showing macro expansion output for learning
  * Enhanced guidance on GDT initialization, loading, and steps to enter protected mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sagi21805/LearnixOS-Book/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->